### PR TITLE
fix(tracker): fixed bugs where grouping wasn't properly being set. ad…

### DIFF
--- a/templates/group-collapse.html
+++ b/templates/group-collapse.html
@@ -1,5 +1,5 @@
 <style>
-    details>summary { 
+   details>summary { 
         list-style: none;
         position: relative;
     }
@@ -25,7 +25,7 @@
 
 
 <summary>
-    <li class="combatant actor directory-item flexrow">
+    <li class="combatant actor directory-item flexrow" >
         <img class="token-image" src="{{ CombatantImage }}" title="{{ CombatantName }}">
         <div class="token-name flexcol">
             <h4>
@@ -35,5 +35,6 @@
         <div class="token-initiative">
             <span class="initiative">{{ CombatantInitiative }}</span>
         </div>
-    </li>
+    </li>        
 </summary>
+


### PR DESCRIPTION
…ded a state to keep the open/collapse values of the header if you update an combatant. added functionality when added new combatent to already existing encounter, to take group's init automatically