### PR TITLE
make the group header optional as a setting. fix group header details…

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -3,5 +3,9 @@
   "COMBAT.RollGroupInitiative": "Roll group initiative",
   "COMBAT.RollGroupInitiativeHint": "Make one roll for an entire group of identical creatures (the same actor) directly from the Combat Tracker \"Roll NPCs\" or \"Roll All\" buttons.",
   "COMBAT.SkipGrouped": "Skip grouped combatants",
-  "COMBAT.SkipGroupedHint": "Skip combatants except for the first in a group."
+  "COMBAT.SkipGroupedHint": "Skip combatants except for the first in a group.",
+  "COMBAT.GroupSame": "Group same actors (EXPERIMENTAL - this has known bugs)",
+  "COMBAT.GroupSameHint": "Group same actors into a header group.",
+  "COMBAT.UseRolledInit": "Use already rolled initiative",
+  "COMBAT.UseRolledInitHint": "When adding a new combatant and there's already initiative for another combatant of the same actor, then use the already rolled initiative."
 }

--- a/templates/combat-config.html
+++ b/templates/combat-config.html
@@ -8,11 +8,27 @@
         {{localize 'COMBAT.RollGroupInitiativeHint'}}
     </p>
 
+    <label for="groupSame">
+        {{localize 'COMBAT.GroupSame'}}
+    </label>
+    <input type="checkbox" name="groupSame" id="groupSame" {{checked groupSame}} data-dtype="Boolean" />
+    <p class="notes">
+        {{localize 'COMBAT.GroupSameHint'}}
+    </p>
+
     <label for="skipGrouped">
         {{localize 'COMBAT.SkipGrouped'}}
     </label>
     <input type="checkbox" name="skipGrouped" id="skipGrouped" {{checked skipGrouped}} data-dtype="Boolean" />
     <p class="notes">
         {{localize 'COMBAT.SkipGroupedHint'}}
+    </p>
+
+    <label for="useRolledInit">
+        {{localize 'COMBAT.UseRolledInit'}}
+    </label>
+    <input type="checkbox" name="useRolledInit" id="useRolledInit" {{checked useRolledInit}} data-dtype="Boolean" />
+    <p class="notes">
+        {{localize 'COMBAT.UseRolledInitHint'}}
     </p>
 </div>

--- a/templates/group-collapse.html
+++ b/templates/group-collapse.html
@@ -1,21 +1,21 @@
 <style>
-   details>summary { 
+    details.group-initiative-header>summary { 
         list-style: none;
         position: relative;
     }
 
-    summary::-webkit-details-marker {
+    details.group-initiative-header>summary::-webkit-details-marker {
         display: none
     }
 
-    summary::after {
+    details.group-initiative-header>summary::after {
         content: ' ►';
         position: absolute;
         right: 47px;
         margin-top: -34px;
     }
 
-    details[open] summary:after {
+    details.group-initiative-header[open] summary:after {
         content: ' ▼';
         position: absolute;
         right: 47px;


### PR DESCRIPTION
- Fix issue with arrow styling on group header overriding other detail groups
- Added setup to enable/disable grouping (default is disable), while I sort out a bunch of issues with the grouping
- Added setup to enable/disable using already rolled initiative when adding the same combatant to the combat. Disabled by default.

Closes #23 
Closes #24 
Closes #25 
Closes #26 
Closes #27 